### PR TITLE
BUGFIX: error de mensajes en el cliente-home

### DIFF
--- a/public/libreria/js/components/cliente-home/cliente-home-presenter.mjs
+++ b/public/libreria/js/components/cliente-home/cliente-home-presenter.mjs
@@ -34,7 +34,7 @@ export class ClienteHomePresenter extends Presenter {
                 
             const textoMensaje = mensajes[mensajes.length - 1].text;
 
-            // Renderizar mensaje si contiene el texto esperado ("Bienvenido, ..." o "Compra relizada...")
+            // Renderizar mensaje si contiene el texto esperado ("Bienvenido, ..." o "Compra realizada...")
             if (textoMensaje.includes("Bienvenido") || textoMensaje.includes("Compra realizada")) {
                 renderUltimoMensaje("#mensajesContainer");
             }


### PR DESCRIPTION
Al volver desde la pantalla que muestra la información de una factura hacia el inicio, se mostraban los mensajes anteriores. Ahora en el inicio se muestra únicamente los mensajes necesarios en el momento necesario