### PR TITLE
Arreglo de los test del proxy

### DIFF
--- a/public/libreria/js/test/proxy.spec.mjs
+++ b/public/libreria/js/test/proxy.spec.mjs
@@ -396,7 +396,16 @@ describe("Tests del Modelo de Librería", function () {
 
     describe("Factura - Excepciones", function () {
       it("debe lanzar error al pagar sin cliente", function () {
-        // Error // Test incompleto en original
+        return libreria.facturarCompraCliente({
+          razonSocial: "Acme S.A.",
+          direccion: "Calle Falsa 123",
+          email: "fact@acme.com",
+          dni: "A0000000Z"
+        }).then(() => {
+          assert.fail("Debería haber lanzado error");
+        }).catch(err => {
+          assert.include(err.message, "Cliente no definido");
+        });
       });
 
       it("debe lanzar error al pagar carro vacío", async function () {


### PR DESCRIPTION
He arreglado el último test que faltaba por implementar, el test Excepciones>Factura>Facturar compra sin especificar cliente.