### PR TITLE
BUGFIX: Error en la url de la API que se usa en el Proxy

### DIFF
--- a/public/libreria/config.mjs
+++ b/public/libreria/config.mjs
@@ -1,0 +1,4 @@
+export const API_BASE_URL =
+  window.location.hostname.includes("localhost")
+    ? "http://localhost:3000/api"
+    : "https://libreria-le6m.onrender.com/api";

--- a/public/libreria/js/model/proxy.mjs
+++ b/public/libreria/js/model/proxy.mjs
@@ -1,10 +1,10 @@
+import { API_BASE_URL } from '../../config.mjs';
+
 // Proxy del cliente para API REST - Práctica 2
 export const ROL = {
   ADMIN: "ADMIN",
   CLIENTE: "CLIENTE",
 };
-
-const API_BASE_URL = 'http://localhost:3000/api';
 
 export class LibreriaProxy {
   constructor() { }


### PR DESCRIPTION
He arreglado el error que había en el proxy. En la página de Render daba error la url, ya que usaba el localhost, pero debería usar la url de la API alojada en Render